### PR TITLE
Added support for fixed case search parameters

### DIFF
--- a/OECaseSearchModule.php
+++ b/OECaseSearchModule.php
@@ -12,6 +12,11 @@ class OECaseSearchModule extends CWebModule
     public $parameters = array();
 
     /**
+     * @var array A list of parameter classes that will always appear on the case search screen.
+     */
+    public $fixedParameters = array();
+
+    /**
      * @var array A List of search providers that can be used for searching. These are specified in the format ['providerID' => 'className'].
      */
     public $providers = array();
@@ -37,6 +42,9 @@ class OECaseSearchModule extends CWebModule
 
     }
 
+    /**
+     * @return string The assets path URL for this module's assets.
+     */
     public function getAssetsUrl()
     {
         if ($this->_assetsUrl === null)
@@ -44,6 +52,23 @@ class OECaseSearchModule extends CWebModule
             $this->_assetsUrl = Yii::app()->assetManager->publish(Yii::getPathOfAlias('application.modules.OECaseSearch.assets'));
         }
         return $this->_assetsUrl;
+    }
+
+    /**
+     * @return array The list of fixed parameter class instances configured for the case search module.
+     */
+    public function getFixedParams()
+    {
+        $fixedParams = array();
+        foreach ($this->fixedParameters as $parameter)
+        {
+            $className = $parameter . 'Parameter';
+            $obj = new $className;
+            $obj->id = $obj->alias();
+            $fixedParams[$obj->id] = $obj;
+        }
+
+        return $fixedParams;
     }
 
     /**
@@ -63,8 +88,8 @@ class OECaseSearchModule extends CWebModule
     }
 
     /**
-     * @param $providerID The unique ID of the search provider you wish to use. This can be found in config/common.php for each included search provider.
-     * @return mixed
+     * @param $providerID mixed The unique ID of the search provider you wish to use. This can be found in config/common.php for each included search provider.
+     * @return SearchProvider The search provider identified by $providerID
      */
     public function getSearchProvider($providerID)
     {

--- a/models/PatientDeceasedParameter.php
+++ b/models/PatientDeceasedParameter.php
@@ -1,0 +1,125 @@
+<?php
+
+class PatientDeceasedParameter extends CaseSearchParameter
+{
+    /**
+     * CaseSearchParameter constructor. This overrides the parent constructor so that the name can be immediately set.
+     * @param string $scenario
+     */
+    public function __construct($scenario = '')
+    {
+        parent::__construct($scenario);
+        $this->name = 'patient_deceased';
+        $this->operation = 0;
+    }
+
+    public function getKey()
+    {
+        // This is a human-readable value, so feel free to change this as required.
+        return 'Patient Deceased';
+    }
+
+    /**
+     * Override this function for any new attributes added to the subclass. Ensure that you invoke the parent function first to obtain and augment the initial list of attribute names.
+     * @return array An array of attribute names.
+     */
+    public function attributeNames()
+    {
+        return parent::attributeNames();
+    }
+
+    /**
+     * Override this function if the parameter subclass has extra validation rules. If doing so, ensure you invoke the parent function first to obtain the initial list of rules.
+     * @return array The validation rules for the parameter.
+     */
+    public function rules()
+    {
+        return array_merge(parent::rules(), array(
+            array('operation', 'boolean'),
+        ));
+    }
+
+    public function renderParameter($id)
+    {
+        // Initialise any rendering variables here.
+        ?>
+      <!-- Place screen-rendering code here. -->
+      <div class="large-3 column">
+          <?php echo CHtml::label('Include deceased patients', false); ?>
+      </div>
+      <div class="large-1 column end">
+          <?php echo CHtml::activeCheckBox($this, "operation"); ?>
+      </div>
+        <?php
+    }
+
+    /**
+     * Generate a SQL fragment representing the subquery of a FROM condition.
+     * @param $searchProvider SearchProvider The search provider. This is used to determine whether or not the search provider is using SQL syntax.
+     * @return mixed The constructed query string.
+     * @throws CHttpException
+     */
+    public function query($searchProvider)
+    {
+        // Construct your SQL query here.
+        if ($searchProvider->getProviderID() === 'mysql') {
+            if ($this->operation == 1) {
+                // Return all patients.
+                return "SELECT id FROM patient";
+            } elseif ($this->operation == 0) {
+                // Return only non-deceased patients.
+                return "SELECT id FROM patient WHERE NOT(is_deceased)";
+            } else {
+                throw new CHttpException(400, 'Invalid value specified');
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get the list of bind values for use in the SQL query.
+     * @return array An array of bind values. The keys correspond to the named binds in the query string.
+     */
+    public function bindValues()
+    {
+        // Construct your list of bind values here. Use the format "bind" => "value".
+        // No binds are used in this query, so return an empty array.
+        return array();
+    }
+
+    /**
+     * Generate a SQL fragment representing a JOIN condition to a subquery.
+     * @param $joinAlias string The alias of the table being joined to.
+     * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
+     * @param $searchProvider SearchProvider The search provider. This is used for an internal query invocation for subqueries.
+     * @return mixed A SQL string representing a complete join condition. Join type is specified within the subclass definition.
+     */
+    public function join($joinAlias, $criteria, $searchProvider)
+    {
+        // Construct your JOIN condition here. Generally this involves wrapping the query in a JOIN condition.
+        $subQuery = $this->query($searchProvider);
+        $query = '';
+        $alias = $this->alias();
+        foreach ($criteria as $key => $column) {
+            // if the string isn't empty, the condition is not the first so prepend it with an AND.
+            if (!empty($query)) {
+                $query .= ' AND ';
+            }
+            $query .= "$joinAlias.$key = $alias.$column";
+        }
+
+        $query = " JOIN ($subQuery) $alias ON " . $query;
+
+        return $query;
+    }
+
+    /**
+     * Get the alias of the database table being used by this parameter instance.
+     * @return string The alias of the table for use in the SQL query.
+     */
+    public function alias()
+    {
+        return "p_de";
+    }
+}

--- a/models/PatientDiagnosisParameter.php
+++ b/models/PatientDiagnosisParameter.php
@@ -54,11 +54,11 @@ class PatientDiagnosisParameter extends CaseSearchParameter
         );
 
         $diagOptions = array(
-            self::DIAGNOSIS_UNCONFIRMED => 'Unconfirmed',
-            self::DIAGNOSIS_CONFIRMED => 'Confirmed'
+            self::DIAGNOSIS_UNCONFIRMED => 'Unconfirmed only',
+            self::DIAGNOSIS_CONFIRMED => 'Confirmed only'
         );
         ?>
-        <div class="large-2 column">
+        <div class="large-1 column">
             <?php echo CHtml::label($this->getKey(), false); ?>
         </div>
         <div class="large-3 column">
@@ -82,8 +82,8 @@ class PatientDiagnosisParameter extends CaseSearchParameter
             ?>
             <?php echo CHtml::error($this, "[$id]textValue"); ?>
         </div>
-        <div class="large-2 column">
-            <?php echo CHtml::activeDropDownList($this, "[$id]isConfirmed", $diagOptions, array('empty' => 'Any'));?>
+        <div class="large-3 column">
+            <?php echo CHtml::activeDropDownList($this, "[$id]isConfirmed", $diagOptions, array('empty' => 'Confirmed/Unconfirmed'));?>
         </div>
         <?php
     }

--- a/tests/unit/models/PatientDeceasedParameterTest.php
+++ b/tests/unit/models/PatientDeceasedParameterTest.php
@@ -1,0 +1,82 @@
+<?php
+class PatientDeceasedParameterTest extends CTestCase
+{
+    protected $parameter;
+    protected $searchProvider;
+
+    protected function setUp()
+    {
+        $this->parameter = new PatientDeceasedParameter();
+        $this->searchProvider = new DBProvider('mysql');
+        $this->parameter->id = 0;
+    }
+
+    protected function tearDown()
+    {
+        unset($this->parameter); // start from scratch for each test.
+        unset($this->searchProvider);
+    }
+
+    /**
+     * @covers PatientDeceasedParameter::query()
+     */
+    public function testQuery()
+    {
+        $correctOps = array(
+            0,
+            1
+        );
+        $invalidOps = array(
+            'LIKE'
+        );
+
+        // Ensure the query is correct for each operator.
+        foreach ($correctOps as $operator) {
+            $this->parameter->operation = $operator;
+            $sqlValue = ($operator === 0) ? "SELECT id FROM patient WHERE NOT(is_deceased)" : "SELECT id FROM patient";
+            $this->assertEquals($sqlValue, $this->parameter->query($this->searchProvider));
+        }
+
+        // Ensure that a HTTP exception is raised if an invalid operation is specified.
+        $this->setExpectedException(CHttpException::class);
+        foreach ($invalidOps as $operator) {
+            $this->parameter->operation = $operator;
+            $this->parameter->query($this->searchProvider);
+        }
+    }
+
+    /**
+     * @covers PatientDeceasedParameter::bindValues()
+     */
+    public function testBindValues()
+    {
+        $this->parameter->operation = 1;
+        $expected = array();
+
+        // Ensure that all bind values are returned.
+        $this->assertEquals($expected, $this->parameter->bindValues());
+    }
+
+    /**
+     * @covers PatientDeceasedParameter::alias()
+     */
+    public function testAlias()
+    {
+        // Ensure that the alias correctly utilises the ID.
+        $expected = 'p_de';
+        $this->assertEquals($expected, $this->parameter->alias());
+    }
+
+    /**
+     * @covers PatientDeceasedParameter::join()
+     */
+    public function testJoin()
+    {
+        $this->parameter->operation = 0;
+        $innerSql = $this->parameter->query($this->searchProvider);
+
+        // Ensure that the JOIN string is correct.
+        $expected = " JOIN ($innerSql) p_de ON p_a_0.id = p_de.id";
+        $this->assertEquals($expected, $this->parameter->join('p_a_0', array('id' => 'id'), $this->searchProvider));
+    }
+}

--- a/tests/unit/models/PatientMedicationParameterTest.php
+++ b/tests/unit/models/PatientMedicationParameterTest.php
@@ -33,7 +33,7 @@ class PatientMedicationParameterTest extends CTestCase
 
         $correctOps = array(
             'LIKE',
-            'UNLIKE',
+            'NOT LIKE',
         );
         $invalidOps = array(
             '=',
@@ -42,7 +42,6 @@ class PatientMedicationParameterTest extends CTestCase
         // Ensure the query is correct for each operator.
         foreach ($correctOps as $operator) {
             $this->object->operation = $operator;
-            $op = ($operator === 'UNLIKE' ? 'NOT LIKE' : 'LIKE');
             $wildcard = '%';
             $sqlValue = "
 SELECT p.id 
@@ -53,8 +52,8 @@ LEFT JOIN drug d
   ON d.id = m.drug_id
 LEFT JOIN medication_drug md
   ON md.id = m.medication_drug_id
-WHERE d.name $op '$wildcard' || :p_m_value_0 || '$wildcard'
-  OR md.name $op '$wildcard' || :p_m_value_0 || '$wildcard'";
+WHERE d.name $operator '$wildcard' || :p_m_value_0 || '$wildcard'
+  OR md.name $operator '$wildcard' || :p_m_value_0 || '$wildcard'";
             $this->assertEquals($sqlValue, $this->object->query($this->searchProvider));
         }
 

--- a/views/caseSearch/fixed_parameter_form.php
+++ b/views/caseSearch/fixed_parameter_form.php
@@ -1,0 +1,10 @@
+<?php
+/* @var $this ParameterController */
+/* @var $model CaseSearchParameter */
+/* @var $form CActiveForm */
+// Fixed parameters use their alias as their ID.
+?>
+
+<div id="<?php echo $id; ?>" class="row field-row">
+    <?php $model->renderParameter($id); ?>
+</div>

--- a/views/caseSearch/index.php
+++ b/views/caseSearch/index.php
@@ -11,94 +11,103 @@ $this->pageTitle = 'OpenEyes - Case Search'
 <h1 class="badge"><?php echo $this->trialContext == null ? 'Case Search' : 'Add Patients to Trial'; ?></h1>
 
 <div class="row">
-        <div class="large-8 column">
-            <div class="form">
-                <?php $form = $this->beginWidget('CActiveForm', array(
-                    'id' => 'search-form'
-                )); ?>
-                <?php if (!empty($form->errorSummary($params))): ?>
-                    <div class="box admin">
-                        <?php echo $form->errorSummary($params); ?>
-                    </div>
-                <?php endif; ?>
+  <div class="large-8 column">
+    <div class="form">
+        <?php $form = $this->beginWidget('CActiveForm', array(
+            'id' => 'search-form',
+        )); ?>
+        <?php if (!empty($form->errorSummary($params))): ?>
+          <div class="box admin">
+              <?php echo $form->errorSummary($params); ?>
+          </div>
+        <?php endif; ?>
 
-                <div id="param-list">
-                    <?php if (isset($params)):
-                        foreach ($params as $id => $param):
-                            $this->renderPartial('parameter_form', array(
-                                'model' => $param,
-                                'id' => $id
-                            ));
-                        endforeach;
-                    endif; ?>
-                </div>
+      <div id="param-list">
+          <?php if (isset($params)):
+              foreach ($params as $id => $param):
+                  $this->renderPartial('parameter_form', array(
+                      'model' => $param,
+                      'id' => $id,
+                  ));
+              endforeach;
+          endif; ?>
+      </div>
+      <div class="box generic">
+          <?php foreach ($fixedParams as $id => $param):
+              $this->renderPartial('fixed_parameter_form', array(
+                  'model' => $param,
+                  'id' => $id,
+              ));
+          endforeach; ?>
+      </div>
 
-              <div class="box generic">
-                <div class="new-param">
-                    <?php echo CHtml::dropDownList('Add Parameter: ', 'Select One...', $paramList, array('id' => 'param')); ?>
-                    <?php echo CHtml::button('Add Parameter', array('id' => 'add-param', 'class' => 'button secondary small')) ?>
-                </div>
-                <div class="search-actions">
-                    <?php echo CHtml::submitButton('Search'); ?>
-                    <?php echo CHtml::button('Clear', array('id' => 'clear-search', 'class' => 'button event-action cancel')) ?>
-                </div>
-
-                <?php $this->endWidget(); ?>
-              </div>
-
-            <div id="results">
-                <?php if (isset($patients)) {
-                    $this->widget('zii.widgets.CListView', array(
-                        'dataProvider' => $patients,
-                        'itemView' => 'search_results',
-                        'emptyText' => '<div class="box generic">No patients found</div>',
-                        'summaryCssClass' => 'box generic',
-                    ));
-                }
-                ?>
-            </div>
+      <div class="box generic">
+        <div class="new-param">
+            <?php echo CHtml::dropDownList('Add Parameter: ', 'Select One...', $paramList, array('id' => 'param')); ?>
+            <?php echo CHtml::button('Add Parameter',
+                array('id' => 'add-param', 'class' => 'button secondary small')) ?>
         </div>
-</div>
+        <div class="search-actions">
+            <?php echo CHtml::submitButton('Search'); ?>
+            <?php echo CHtml::button('Clear', array('id' => 'clear-search', 'class' => 'button event-action cancel')) ?>
+        </div>
 
-<script type="text/javascript">
-        function addPatientToTrial(patient_id, trial_id) {
-            $.ajax({
-                url: '<?php echo Yii::app()->createUrl('/OETrial/trial/addPatient'); ?>',
-                data: {id: trial_id, patient_id: patient_id},
-                type: 'GET',
-                success: function (response) {
-                    $('#add-to-trial-link-' + patient_id).hide();
-                    $('#remove-from-trial-link-' + patient_id).show();
-                },
-                error: function (response) {
-                    new OpenEyes.UI.Dialog.Alert({
-                        content: "Sorry, an internal error occurred and we were unable to add the patient to te trial.\n\nPlease contact support for assistance."
-                    }).open();
-                },
-            });
-        }
+          <?php $this->endWidget(); ?>
+      </div>
 
-        function removePatientFromTrial(patient_id, trial_id) {
-            $.ajax({
-                url: '<?php echo Yii::app()->createUrl('/OETrial/trial/removePatient'); ?>',
-                data: {id: trial_id, patient_id: patient_id},
-                type: 'GET',
-                success: function (response) {
-                    $('#remove-from-trial-link-' + patient_id).hide();
-                    $('#add-to-trial-link-' + patient_id).show();
-                },
-                error: function (response) {
-                    new OpenEyes.UI.Dialog.Alert({
-                        content: "Sorry, an internal error occurred and we were unable to remove the patient from the trial.\n\nPlease contact support for assistance."
-                    }).open();
-                },
-            });
-        }
-</script>
+      <div id="results">
+          <?php if (isset($patients)) {
+              $this->widget('zii.widgets.CListView', array(
+                  'dataProvider' => $patients,
+                  'itemView' => 'search_results',
+                  'emptyText' => '<div class="box generic">No patients found</div>',
+                  'summaryCssClass' => 'box generic',
+              ));
+          }
+          ?>
+      </div>
+    </div>
+  </div>
+
+  <script type="text/javascript">
+    function addPatientToTrial(patient_id, trial_id) {
+      $.ajax({
+        url: '<?php echo Yii::app()->createUrl('/OETrial/trial/addPatient'); ?>',
+        data: {id: trial_id, patient_id: patient_id},
+        type: 'GET',
+        success: function (response) {
+          $('#add-to-trial-link-' + patient_id).hide();
+          $('#remove-from-trial-link-' + patient_id).show();
+        },
+        error: function (response) {
+          new OpenEyes.UI.Dialog.Alert({
+            content: "Sorry, an internal error occurred and we were unable to add the patient to te trial.\n\nPlease contact support for assistance."
+          }).open();
+        },
+      });
+    }
+
+    function removePatientFromTrial(patient_id, trial_id) {
+      $.ajax({
+        url: '<?php echo Yii::app()->createUrl('/OETrial/trial/removePatient'); ?>',
+        data: {id: trial_id, patient_id: patient_id},
+        type: 'GET',
+        success: function (response) {
+          $('#remove-from-trial-link-' + patient_id).hide();
+          $('#add-to-trial-link-' + patient_id).show();
+        },
+        error: function (response) {
+          new OpenEyes.UI.Dialog.Alert({
+            content: "Sorry, an internal error occurred and we were unable to remove the patient from the trial.\n\nPlease contact support for assistance."
+          }).open();
+        },
+      });
+    }
+  </script>
 
 
-<?php
-Yii::app()->clientScript->registerScript('addParam', "
+    <?php
+    Yii::app()->clientScript->registerScript('addParam', "
 $('#add-param').click(function() {
   var id = $('.parameter').last().attr('id') ? ($('.parameter').last().attr('id')) : -1;
   $.ajax({
@@ -119,10 +128,10 @@ $('#clear-search').click(function() {
     }
   });
 });");
-Yii::app()->clientScript->registerScriptFile($this->module->getAssetsUrl() . '/js/QueryBuilder.js');
-Yii::app()->clientScript->registerCssFile($this->module->getAssetsUrl() . '/css/QueryBuilder.css');
+    Yii::app()->clientScript->registerScriptFile($this->module->getAssetsUrl() . '/js/QueryBuilder.js');
+    Yii::app()->clientScript->registerCssFile($this->module->getAssetsUrl() . '/css/QueryBuilder.css');
 
-$assetPath = Yii::app()->getAssetManager()->publish(Yii::getPathOfAlias('application.assets'), false, -1);
-Yii::app()->getClientScript()->registerScriptFile($assetPath . '/js/toggle-section.js');
-?>
+    $assetPath = Yii::app()->getAssetManager()->publish(Yii::getPathOfAlias('application.assets'), false, -1);
+    Yii::app()->getClientScript()->registerScriptFile($assetPath . '/js/toggle-section.js');
+    ?>
 


### PR DESCRIPTION
Changed visible options for diagnosis confirmation to reflect their true meaning and context.
Added support for fixed parameters (ie. parameters that are always available). To add a fixed parameter, include the relevant CaseSearchParameter subclass in the fixedParameters property array for the OECaseSearch module.
Added Patient Deceased fixed case search parameter. This will allow for deceased patient to be filtered out of case search.