### PR TITLE
Replaced getter function for provider ID with a magic method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,32 @@
 Advanced Case searching module for OpenEyes.
 
 ##Configuration
-To enable this module in OpenEyes, add the following lines to config/common.php:
+To enable this module in OpenEyes, add OECaseSearch to the module list in any common config file.
 
-    'OECaseSearch' => array(
-        'parameters' => array(
-            'PatientAge',
-            'PatientDiagnosis',
-            'PatientMedication',
-            'FamilyHistory',
-            'PatientAllergy'
-            // Add each parameter class you wish to include in case search here (wihout the 'Parameter' prefix).
-        ),
-        'providers' => array(
-            'mysql' => 'DBProvider',
-            // Include any other search provider classes you wish to use here. Format is providerID => providerClass
-        )
+## Creating your own Case Search parameters
+To create a new Case search parameter type, simply:
+
+1. Enable Gii.
+2. Navigate to Gii in your web browser of choice using the following URL: `http://<openeyes_url>/gii`.
+3. After logging in, click *CaseSearchParameter Generator*.
+4. On the next screen, enter in the class name of the parameter.
+5. The SQL alias prefix and parameter name fields will be pre-filled based on the value entered for the class name. If the values need to be different, feel free to change them.
+6. Enter in the name of each attribute the parameter will have in addition to its name and selected operator. This can be left blank.
+7. Click Preview. This will generate a snapshot of the parameter class.
+8. If you are satisfied with the auto-generated code, click Generate. This will add the parameter to the models folder within the OECaseSearch module.
+9. Once the code has been generated, implement the query, join and renderParameter functions.
+10. Add any validation rules on the attributes to the rules function.
+11. In `OECaseSearch/config/common.php`, add the class name to the parameters and/or fixedParameters arrays.
+12. You're all set! Save your changes and add the parameter to your next case search!
+
+## Search Providers
+The OECaseSearch module supports the use of several different search providers concurrently, whether that be a SQL implementation or an indexed search such as Elasticsearch or SOLR. Provisioning between providers is performed within the CaseSearchController and so is user-defined.
+
+A MySQL-supported search provider, DBProvider, is provided by default (which may also support other SQL-based databases as well); however other search providers can be added by creating subclasses of the SearchProvider abstract class.
+To define a new search provider, the subclass must implement the executeSearch($parameters) function and possess a unique providerID. Additionally, any defined case search parameter classes should include handling for each different provider, whether it be MySQL or SOLR, for instance.
+
+To add these subclasses to OECaseSearch, add the class name to the 'providers' array in `config/common.php` using its unique identifier as the key eg.
+    
+    'providers' = array(
+        'providerID' => 'ProviderClass'
     ),

--- a/components/SearchProvider.php
+++ b/components/SearchProvider.php
@@ -5,7 +5,10 @@
  */
 abstract class SearchProvider
 {
-    private $providerID;
+    /**
+     * @var mixed Unique provider ID
+     */
+    protected $_providerID;
 
     /**
      * SearchProvider constructor.
@@ -13,26 +16,36 @@ abstract class SearchProvider
      */
     public function __construct($id)
     {
-        $this->providerID = $id;
+        $this->_providerID = $id;
     }
 
     /**
-     * Perform a search using the specified parameters.
+     * Magic get method to get the provider ID without a getter while also preventing setting it directly.
+     * @param $name string The property name
+     * @return null|mixed The value of the given property (if it exists).
+     */
+    public final function __get($name)
+    {
+        if ($name === 'providerID')
+        {
+            return $this->_providerID;
+        }
+        $trace = debug_backtrace();
+        trigger_error('Undefined property via __get(): ' . $name .
+        ' in ' . $trace[0]['file'] .
+        ' on line '. $trace[0]['line'],
+            E_USER_NOTICE);
+        return null;
+    }
+
+    /**
+     * Perform a search using the specified parameters. Call this function to run the search rather than executeSearch.
      * @param $parameters array A list of CaseSearchParameter objects representing a search parameter.
      * @return mixed Search results. This will take whatever form is specified within the subclass' executeSearch implementation.
      */
     public final function search($parameters)
     {
         return $this->executeSearch($parameters);
-    }
-
-    /**
-     * Get the search provider's unique ID.
-     * @return mixed The search provider's unique ID.
-     */
-    public final function getProviderID()
-    {
-        return $this->providerID;
     }
 
     /**

--- a/models/FamilyHistoryParameter.php
+++ b/models/FamilyHistoryParameter.php
@@ -69,23 +69,9 @@ class FamilyHistoryParameter extends CaseSearchParameter
         $sideList = FamilyHistorySide::model()->findAll();
         $conditionList = FamilyHistoryCondition::model()->findAll();
 
-        $relatives = array();
-        $sides = array();
-        $conditions = array();
-
-        foreach ($relativeList as $relative) {
-            $relatives[$relative->id] = $relative->name;
-        }
-
-        foreach ($sideList as $side) {
-            if ($side !== 'N/A') {
-                $sides[$side->id] = $side->name;
-            }
-        }
-
-        foreach ($conditionList as $condition) {
-            $conditions[$condition->id] = $condition->name;
-        }
+        $relatives = CHtml::listData($relativeList, 'id', 'name');
+        $sides = CHtml::listData($sideList, 'id', 'name');
+        $conditions = CHtml::listData($conditionList, 'id', 'name');
         // Place screen-rendering code here.
 
         ?>
@@ -105,7 +91,7 @@ class FamilyHistoryParameter extends CaseSearchParameter
             <?php echo CHtml::activeDropDownList($this, "[$id]operation", $ops, array('prompt' => 'Select One...')); ?>
             <?php echo CHtml::error($this, "[$id]operation"); ?>
         </div>
-        <div class="large-2 column">';
+        <div class="large-2 column">
             <?php echo CHtml::activeDropDownList($this, "[$id]condition", $conditions, array('prompt' => 'Select One...')); ?>
             <?php echo CHtml::error($this, "[$id]condition"); ?>
         </div>
@@ -122,7 +108,7 @@ class FamilyHistoryParameter extends CaseSearchParameter
     public function query($searchProvider)
     {
         // Construct your SQL query here.
-        if ($searchProvider->getProviderID()  === 'mysql')
+        if ($searchProvider->providerID === 'mysql')
         {
             switch ($this->operation)
             {
@@ -169,7 +155,7 @@ WHERE (:f_h_side_$this->id IS NULL OR fh.side_id = :f_h_side_$this->id)
     /**
     * Generate a SQL fragment representing a JOIN condition to a subquery.
     * @param $joinAlias string The alias of the table being joined to.
-    * @param $criteria string An array of join conditions. The ID for each element is the column name from the aliased table.
+    * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
     * @param $searchProvider SearchProvider The search provider. This is used for an internal query invocation for subqueries.
     * @return string A SQL string representing a complete join condition. Join type is specified within the subclass definition.
     */

--- a/models/PatientAgeParameter.php
+++ b/models/PatientAgeParameter.php
@@ -167,7 +167,7 @@ class PatientAgeParameter extends CaseSearchParameter
      */
     public function query($searchProvider)
     {
-        if ($searchProvider->getProviderID()  === 'mysql')
+        if ($searchProvider->providerID  === 'mysql')
         {
             switch ($this->operation)
             {
@@ -247,7 +247,7 @@ class PatientAgeParameter extends CaseSearchParameter
 
     /**
      * @param $joinAlias string Alias of the table.
-     * @param $criteria string Criteria used for JOINs.
+     * @param $criteria array Criteria used for JOINs.
      * @param $searchProvider SearchProvider The search provider constructing the JOIN SQL statement.
      * @return string The constructed SQL JOIN statement.
      */

--- a/models/PatientAllergyParameter.php
+++ b/models/PatientAllergyParameter.php
@@ -67,7 +67,7 @@ class PatientAllergyParameter extends CaseSearchParameter
                 'name' => 'allergy',
                 'model' => $this,
                 'attribute' => "[$id]textValue",
-                'source' => Yii::app()->urlManager->createUrl('OECaseSearch/AutoComplete/commonAllergies'),
+                'source' => Yii::app()->controller->createUrl('AutoComplete/commonAllergies'),
                 'options' => array(
                     'minLength' => 2,
                 ),
@@ -89,7 +89,7 @@ class PatientAllergyParameter extends CaseSearchParameter
     public function query($searchProvider)
     {
         // Construct your SQL query here.
-        if ($searchProvider->getProviderID()  === 'mysql')
+        if ($searchProvider->providerID === 'mysql')
         {
             switch ($this->operation)
             {
@@ -133,9 +133,9 @@ WHERE a.name $op :p_al_textValue_$this->id";
 
     /**
     * Generate a SQL fragment representing a JOIN condition to a subquery.
-    * @param $joinAlias The alias of the table being joined to.
-    * @param $criteria An array of join conditions. The ID for each element is the column name from the aliased table.
-    * @param $searchProvider The search provider. This is used for an internal query invocation for subqueries.
+    * @param $joinAlias string The alias of the table being joined to.
+    * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
+    * @param $searchProvider SearchProvider The search provider. This is used for an internal query invocation for subqueries.
     * @return string A SQL string representing a complete join condition. Join type is specified within the subclass definition.
     */
     public function join($joinAlias, $criteria, $searchProvider)

--- a/models/PatientDeceasedParameter.php
+++ b/models/PatientDeceasedParameter.php
@@ -62,7 +62,7 @@ class PatientDeceasedParameter extends CaseSearchParameter
     public function query($searchProvider)
     {
         // Construct your SQL query here.
-        if ($searchProvider->getProviderID() === 'mysql') {
+        if ($searchProvider->providerID === 'mysql') {
             if ($this->operation === '1') {
                 // Return all patients.
                 return "SELECT id FROM patient";

--- a/models/PatientDiagnosisParameter.php
+++ b/models/PatientDiagnosisParameter.php
@@ -72,7 +72,7 @@ class PatientDiagnosisParameter extends CaseSearchParameter
                 'name' => 'diagnosis',
                 'model' => $this,
                 'attribute' => "[$id]textValue",
-                'source' => Yii::app()->urlManager->createUrl('OECaseSearch/AutoComplete/commonDiagnoses'),
+                'source' => Yii::app()->controller->createUrl('AutoComplete/commonDiagnoses'),
                 'options' => array(
                     'minLength' => 2,
                 ),
@@ -90,14 +90,14 @@ class PatientDiagnosisParameter extends CaseSearchParameter
 
     /**
      * Generate a SQL fragment representing the subquery of a FROM condition.
-     * @param $searchProvider The search provider. This is used to determine whether or not the search provider is using SQL syntax.
+     * @param $searchProvider SearchProvider The search provider. This is used to determine whether or not the search provider is using SQL syntax.
      * @return mixed The constructed query string.
      * @throws CHttpException
      */
     public function query($searchProvider)
     {
         // Construct your SQL query here.
-        if ($searchProvider->getProviderID()  === 'mysql')
+        if ($searchProvider->providerID  === 'mysql')
         {
             $query = "SELECT p.id 
 FROM patient p 
@@ -146,9 +146,9 @@ WHERE p.id NOT IN (
 
     /**
     * Generate a SQL fragment representing a JOIN condition to a subquery.
-    * @param $joinAlias The alias of the table being joined to.
-    * @param $criteria An array of join conditions. The ID for each element is the column name from the aliased table.
-    * @param $searchProvider The search provider. This is used for an internal query invocation for subqueries.
+    * @param $joinAlias string The alias of the table being joined to.
+    * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
+    * @param $searchProvider SearchProvider The search provider. This is used for an internal query invocation for subqueries.
     * @return string A SQL string representing a complete join condition. Join type is specified within the subclass definition.
     */
     public function join($joinAlias, $criteria, $searchProvider)

--- a/models/PreviousTrialParameter.php
+++ b/models/PreviousTrialParameter.php
@@ -101,7 +101,7 @@ class PreviousTrialParameter extends CaseSearchParameter
     public function query($searchProvider)
     {
         // Construct your SQL query here.
-        if ($searchProvider->getProviderID() === 'mysql') {
+        if ($searchProvider->providerID === 'mysql') {
             switch ($this->operation) {
                 case '=':
                     $joinCondition = 'JOIN';

--- a/tests/unit/components/DBProviderTest.php
+++ b/tests/unit/components/DBProviderTest.php
@@ -8,6 +8,9 @@
  */
 class DBProviderTest extends CDbTestCase
 {
+    /**
+     * @var DBProvider search provider.
+     */
     protected $provider;
 
     public static function setupBeforeClass()
@@ -27,8 +30,9 @@ class DBProviderTest extends CDbTestCase
 
     /**
      * @covers DBProvider::executeSearch()
+     * @covers DBProvider::search()
      */
-    public function testExecuteSearch()
+    public function testSearch()
     {
         // executeSearch is a protected function so it needs to be run via DBProvider's parent function, search.
         $testParameter1 = new PatientAgeParameter();
@@ -44,5 +48,19 @@ class DBProviderTest extends CDbTestCase
         $results = $this->provider->search(array($testParameter1, $testParameter2));
 
         $this->assertNotEmpty($results);
+    }
+
+    public function testMagicMethods()
+    {
+        // Ensure that the provider ID can be retrieved by simply referring to it.
+        $this->assertEquals('mysql', $this->provider->providerID);
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error_Notice
+     */
+    public function testMagicMethodException()
+    {
+        $value = $this->provider->fakeProp;
     }
 }

--- a/tests/unit/models/PatientMedicationParameterTest.php
+++ b/tests/unit/models/PatientMedicationParameterTest.php
@@ -46,10 +46,13 @@ class PatientMedicationParameterTest extends CTestCase
         foreach ($correctOps as $operator) {
             $this->object->operation = $operator;
             $wildcard = '%';
-            $sqlValue = "
+
+            if ($operator === 'LIKE')
+            {
+                $sqlValue = "
 SELECT p.id 
 FROM patient p 
-JOIN medication m 
+LEFT JOIN medication m 
   ON m.patient_id = p.id 
 LEFT JOIN drug d 
   ON d.id = m.drug_id
@@ -57,6 +60,22 @@ LEFT JOIN medication_drug md
   ON md.id = m.medication_drug_id
 WHERE d.name $operator '$wildcard' || :p_m_value_0 || '$wildcard'
   OR md.name $operator '$wildcard' || :p_m_value_0 || '$wildcard'";
+            }
+            elseif ($operator === 'NOT LIKE')
+            {
+                $sqlValue = "
+SELECT p.id 
+FROM patient p 
+LEFT JOIN medication m 
+  ON m.patient_id = p.id 
+LEFT JOIN drug d 
+  ON d.id = m.drug_id
+LEFT JOIN medication_drug md
+  ON md.id = m.medication_drug_id
+WHERE d.name $operator '$wildcard' || :p_m_value_0 || '$wildcard'
+  OR md.name $operator '$wildcard' || :p_m_value_0 || '$wildcard'
+  OR m.id IS NULL";
+            }
             $this->assertEquals($sqlValue, $this->object->query($this->searchProvider));
         }
 


### PR DESCRIPTION
This will allow retrieval of the provider ID using just the property, but will prevent mutation of the value outside of the constructor.
Added customisation instructions for adding new parameters and search providers to README.md.
Patient Medication parameter autocomplete now uses drug/medication_drug as the basis of its search rather thean Medication (which is empty until a patient has at least 1 medication).
Patient medication parameter now correctly returns patients without medications when the 'has not taken' option is selected.
Now using CHtml::listData helper function to build option arrays for family history drop-down lists rather than manually building option arrays.
Updated unit tests and case search parameters to reflect changes to provider ID retrieval.
Now using the controller as the basis for URL generation for autocomplete widgets rather than the application's URL manager.