### PR TITLE
Case Search results are now ordered in ascending order by surname and first name.

### DIFF
--- a/controllers/CaseSearchController.php
+++ b/controllers/CaseSearchController.php
@@ -90,7 +90,9 @@ class CaseSearchController extends BaseModuleController
         }
 
         // If there are no IDs found, pass -1 as the value (as this will not match with anything).
-        $criteria->compare('id', empty($ids) ? -1 : $ids);
+        $criteria->compare('t.id', empty($ids) ? -1 : $ids);
+        $criteria->with = 'contact';
+        $criteria->order = 'last_name, first_name';
 
         // A data provider is used here to allow faster search times. Results are iterated through using the data provider's pagination functionality and the CListView widget's pager.
         $patientData = new CActiveDataProvider('Patient', array(

--- a/models/PreviousTrialParameter.php
+++ b/models/PreviousTrialParameter.php
@@ -69,22 +69,25 @@ class PreviousTrialParameter extends CaseSearchParameter
               array('empty' => 'Any Trial', 'onchange' => 'getTrialList(this)')); ?>
       </div>
 
+      <div class="large-3 column trial-list">
+        <p></p>
+      </div>
+
       <script type="text/javascript">
         function getTrialList(target) {
           var type = parseInt($(target).val());
           var trialHtml = null;
-          $(target).parent().parent().find('.trial-list').remove();
 
           if (type === <?php echo Trial::TRIAL_TYPE_INTERVENTION; ?>) {
             trialHtml = <?php echo $this->getInterventionTrialList($this->id); ?>;
-            $(target).parent().parent().find('.trial-type').after(trialHtml);
+            $(target).parent().parent().find('.trial-list').replaceWith(trialHtml);
           }
           else if (type === <?php echo Trial::TRIAL_TYPE_NON_INTERVENTION; ?>) {
             trialHtml = <?php echo $this->getNonInterventionTrialList($this->id); ?>;
-            $(target).parent().parent().find('.trial-type').after(trialHtml);
+            $(target).parent().parent().find('.trial-list').replaceWith(trialHtml);
           }
           else {
-            $(target).parent().parent().find('.trial-list').remove();
+            $(target).parent().parent().find('.trial-list').replaceWith('<div class="large-3 column trial-list"><p></p></div>');
           }
         }
       </script>

--- a/views/caseSearch/search_results.php
+++ b/views/caseSearch/search_results.php
@@ -6,7 +6,10 @@
 ?>
 
 <div class="result box generic">
-  <h3 class="box-title"><?php echo CHtml::link($data->contact->last_name . ', ' . $data->contact->first_name . ($data->is_deceased ? ' (Deceased)' : ''),
+  <h3 class="box-title"><?php echo CHtml::link($data->contact->last_name
+          . ', ' . $data->contact->first_name
+          . ($data->is_deceased ? ' (Deceased)' : '')
+          . ($data->hasUnconfirmedDiagnoses() ? ' (Unconfirmed)' : ''),
           array('/patient/view', 'id' => $data->id), array('target' => '_blank')); ?></h3>
   <div class="row data-row">
     <div class="large-12 column">


### PR DESCRIPTION
Added blank space between Remove link and drop-down for Previous Trial parameter when there is no trial type selected.