### PR TITLE
Fixed an issue with the Patient Diagnosis Case Search Parameter

### DIFF
--- a/models/PatientDiagnosisParameter.php
+++ b/models/PatientDiagnosisParameter.php
@@ -111,7 +111,7 @@ WHERE LOWER(d.term) LIKE LOWER(:p_d_value_$this->id)";
         if ($this->isConfirmed === '0') {
             $query .= " AND sd.is_confirmed = :p_d_confirmed_$this->id";
         } elseif ($this->isConfirmed === '1') {
-            $query .= " AND (:p_d_confirmed_$this->id = " . self::DIAGNOSIS_CONFIRMED . " AND sd.is_confirmed IS NULL) OR sd.is_confirmed = :p_d_confirmed_$this->id";
+            $query .= " AND ((:p_d_confirmed_$this->id = " . self::DIAGNOSIS_CONFIRMED . " AND sd.is_confirmed IS NULL) OR sd.is_confirmed = :p_d_confirmed_$this->id)";
         }
         switch ($this->operation) {
             case 'LIKE':


### PR DESCRIPTION
Fixed an issue where searching for patients with a particular confirmed diagnosis would result in every patient with any confirmed diagnoses being returned (instead of every patient with the diagnosis in the parameter)