### PR TITLE
Overhauled database searching mechanism in DBProvider

### DIFF
--- a/OECaseSearchModule.php
+++ b/OECaseSearchModule.php
@@ -7,6 +7,9 @@ class OECaseSearchModule extends CWebModule
 {
     private $searchProviders = array();
     private $_assetsUrl;
+    /**
+     * @var array
+     */
     private $config;
 
     public function init()
@@ -53,14 +56,15 @@ class OECaseSearchModule extends CWebModule
     public function getFixedParams()
     {
         $fixedParams = array();
+        $count = 0;
         foreach ($this->config['fixedParameters'] as $group)
         {
             foreach ($group as $parameter)
             {
                 $className = $parameter . 'Parameter';
                 $obj = new $className;
-                $obj->id = 'fixed';
-                $fixedParams[$obj->alias()] = $obj;
+                $obj->id = "fixed_$count";
+                $fixedParams[$obj->id] = $obj;
             }
         }
         return $fixedParams;

--- a/components/DBProvider.php
+++ b/components/DBProvider.php
@@ -21,8 +21,9 @@ class DBProvider extends SearchProvider
             if ($param instanceof DBProviderInterface) {
                 // Get the query component of the parameter, append it in the correct manner and augment the list of binds.
                 $from = $param->query($this);
-                $queryStr .= ($pos++ === 0) ? "WHERE p.id IN ($from)" : " AND p.id IN ($from)";
+                $queryStr .= ($pos === 0) ? "WHERE p.id IN ($from)" : " AND p.id IN ($from)";
                 $bindValues = array_merge($bindValues, $param->bindValues());
+                $pos++;
             }
         }
 

--- a/components/DBProvider.php
+++ b/components/DBProvider.php
@@ -11,23 +11,18 @@ class DBProvider extends SearchProvider
      */
     protected function executeSearch($criteria)
     {
-        $lastID = -1;
         $bindValues = array();
-        $queryStr = null;
+        $queryStr = "SELECT DISTINCT p.id FROM patient p ";
+        $pos = 0;
 
         // Construct the SQL search string using each parameter as a separate dataset merged using JOINs.
         foreach ($criteria as $id => $param) {
             // Ignore any case search parameters that do not implement DBProviderInterface
-            if ($criteria instanceof DBProviderInterface) {
-                if ($queryStr !== null) {
-                    $queryStr .= $param->join($criteria[$lastID]->alias(), array('id' => 'id'), $this);
-                } else {
-                    $from = $param->query($this);
-                    $alias = $param->alias();
-                    $queryStr = "SELECT $alias.id FROM ($from) $alias";
-                }
+            if ($param instanceof DBProviderInterface) {
+                // Get the query component of the parameter, append it in the correct manner and augment the list of binds.
+                $from = $param->query($this);
+                $queryStr .= ($pos++ === 0) ? "WHERE p.id IN ($from)" : " AND p.id IN ($from)";
                 $bindValues = array_merge($bindValues, $param->bindValues());
-                $lastID = $id;
             }
         }
 

--- a/components/DBProviderInterface.php
+++ b/components/DBProviderInterface.php
@@ -17,19 +17,4 @@ interface DBProviderInterface
      * @return array An array of bind values. The keys correspond to the named binds in the query string.
      */
     public function bindValues();
-
-    /**
-     * Generate a SQL fragment representing a JOIN condition to a subquery.
-     * @param $joinAlias string The alias of the table being joined to.
-     * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
-     * @param $searchProvider DBProvider search provider. This is used for an internal query invocation for subqueries.
-     * @return string A SQL string representing a complete join condition. Join type is specified within the subclass definition.
-     */
-    public function join($joinAlias, $criteria, $searchProvider);
-
-    /**
-     * Get the alias of the database table being used by this parameter instance.
-     * @return string The alias of the table for use in the SQL query.
-     */
-    public function alias();
 }

--- a/controllers/CaseSearchController.php
+++ b/controllers/CaseSearchController.php
@@ -40,7 +40,7 @@ class CaseSearchController extends BaseModuleController
         }
 
         $this->trialContext = null;
-        if ($trial_id != null) {
+        if ($trial_id !== null) {
             $this->trialContext = Trial::model()->findByPk($trial_id);
         }
 
@@ -73,8 +73,8 @@ class CaseSearchController extends BaseModuleController
             }
         }
 
-        // This should only run if there are parameters and if all parameters are valid
-        if (!empty($parameters) and $valid) {
+        // This can always run as there will always be at least 1 fixed parameter included in the search. Just as long as it is valid!
+        if ($valid) {
             $mergedParams = array_merge($parameters, $fixedParameters);
             $this->actionClear();
             $searchProvider = $this->module->getSearchProvider('mysql');
@@ -88,7 +88,7 @@ class CaseSearchController extends BaseModuleController
             }
 
             // Only copy to the $_SESSION array if it isn't already there - Shallow copy is done at the start if it is already set.
-            if (!isset($_SESSION['last_search']) or empty($_SESSION['last_search'])) {
+            if (!isset($_SESSION['last_search']) || empty($_SESSION['last_search'])) {
                 $_SESSION['last_search'] = $ids;
             }
         }

--- a/models/FamilyHistoryParameter.php
+++ b/models/FamilyHistoryParameter.php
@@ -146,39 +146,4 @@ WHERE (:f_h_side_$this->id IS NULL OR fh.side_id = :f_h_side_$this->id)
             "f_h_condition_$this->id" => $this->condition,
         );
     }
-
-    /**
-     * Generate a SQL fragment representing a JOIN condition to a subquery.
-     * @param $joinAlias string The alias of the table being joined to.
-     * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
-     * @param $searchProvider DBProvider The search provider. This is used for an internal query invocation for subqueries.
-     * @return string A SQL string representing a complete join condition. Join type is specified within the subclass definition.
-     */
-    public function join($joinAlias, $criteria, $searchProvider)
-    {
-        // Construct your JOIN condition here. Generally this involves wrapping the query in a JOIN condition.
-        $subQuery = $this->query($searchProvider);
-        $query = '';
-        $alias = $this->alias();
-        foreach ($criteria as $key => $column) {
-            // if the string isn't empty, the condition is not the first so prepend it with an AND.
-            if (!empty($query)) {
-                $query .= ' AND ';
-            }
-            $query .= "$joinAlias.$key = $alias.$column";
-        }
-
-        $query = " JOIN ($subQuery) $alias ON " . $query;
-
-        return $query;
-    }
-
-    /**
-     * Get the alias of the database table being used by this parameter instance.
-     * @return string The alias of the table for use in the SQL query.
-     */
-    public function alias()
-    {
-        return "f_h_$this->id";
-    }
 }

--- a/models/PatientAgeParameter.php
+++ b/models/PatientAgeParameter.php
@@ -76,12 +76,12 @@ class PatientAgeParameter extends CaseSearchParameter implements DBProviderInter
     public function values($attribute)
     {
         $label = $this->attributeLabels()[$attribute];
-        if ($attribute === 'minValue' or $attribute === 'maxValue') {
-            if ($this->operation === 'BETWEEN' and strlen($this->$attribute) === 0) {
+        if ($attribute === 'minValue' || $attribute === 'maxValue') {
+            if ($this->operation === 'BETWEEN' && $this->$attribute === '') {
                 $this->addError($attribute, "$label must be specified.");
             }
         } else {
-            if ($this->operation !== 'BETWEEN' and strlen($this->$attribute) === 0) {
+            if ($this->operation !== 'BETWEEN' && $this->$attribute === '') {
                 $this->addError($attribute, "$label must be specified.");
             }
         }
@@ -198,51 +198,18 @@ class PatientAgeParameter extends CaseSearchParameter implements DBProviderInter
     public function bindValues()
     {
         $bindValues = array();
-        if (strlen($this->minValue) !== 0) {
+        if ($this->minValue !== '' && $this->minValue !== null) {
             $bindValues["p_a_min_$this->id"] = (int)$this->minValue;
         }
 
-        if (strlen($this->maxValue) !== 0) {
+        if ($this->maxValue !== '' && $this->maxValue !== null) {
             $bindValues["p_a_max_$this->id"] = (int)$this->maxValue;
         }
 
-        if (strlen($this->textValue) !== 0) {
+        if ($this->textValue !== '' && $this->textValue !== null) {
             $bindValues["p_a_value_$this->id"] = (int)$this->textValue;
         }
 
         return $bindValues;
-    }
-
-    /**
-     * @return string Alias of the patient age parameter. Form is "p_a_#id".
-     */
-    public function alias()
-    {
-        return "p_a_$this->id";
-    }
-
-    /**
-     * @param $joinAlias string Alias of the table.
-     * @param $criteria array Criteria used for JOINs.
-     * @param $searchProvider DBProvider The search provider constructing the JOIN SQL statement.
-     * @return string The constructed SQL JOIN statement.
-     */
-    public function join($joinAlias, $criteria, $searchProvider)
-    {
-        // Construct your JOIN condition here. Generally this involves wrapping the query in a JOIN condition.
-        $subQuery = $this->query($searchProvider);
-        $query = '';
-        $alias = $this->alias();
-        foreach ($criteria as $key => $column) {
-            // if the string isn't empty, the condition is not the first so prepend it with an AND.
-            if (!empty($query)) {
-                $query .= ' AND ';
-            }
-            $query .= "$joinAlias.$key = $alias.$column";
-        }
-
-        $query = " JOIN ($subQuery) $alias ON " . $query;
-
-        return $query;
     }
 }

--- a/models/PatientAllergyParameter.php
+++ b/models/PatientAllergyParameter.php
@@ -126,39 +126,4 @@ WHERE p1.id NOT IN (
             "p_al_textValue_$this->id" => $this->textValue,
         );
     }
-
-    /**
-     * Generate a SQL fragment representing a JOIN condition to a subquery.
-     * @param $joinAlias string The alias of the table being joined to.
-     * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
-     * @param $searchProvider DBProvider The search provider. This is used for an internal query invocation for subqueries.
-     * @return string A SQL string representing a complete join condition. Join type is specified within the subclass definition.
-     */
-    public function join($joinAlias, $criteria, $searchProvider)
-    {
-        // Construct your JOIN condition here. Generally this involves wrapping the query in a JOIN condition.
-        $subQuery = $this->query($searchProvider);
-        $query = '';
-        $alias = $this->alias();
-        foreach ($criteria as $key => $column) {
-            // if the string isn't empty, the condition is not the first so prepend it with an AND.
-            if (!empty($query)) {
-                $query .= ' AND ';
-            }
-            $query .= "$joinAlias.$key = $alias.$column";
-        }
-
-        $query = " JOIN ($subQuery) $alias ON " . $query;
-
-        return $query;
-    }
-
-    /**
-     * Get the alias of the database table being used by this parameter instance.
-     * @return string The alias of the table for use in the SQL query.
-     */
-    public function alias()
-    {
-        return "p_al_$this->id";
-    }
 }

--- a/models/PatientDeceasedParameter.php
+++ b/models/PatientDeceasedParameter.php
@@ -88,39 +88,4 @@ class PatientDeceasedParameter extends CaseSearchParameter implements DBProvider
         // No binds are used in this query, so return an empty array.
         return array();
     }
-
-    /**
-     * Generate a SQL fragment representing a JOIN condition to a subquery.
-     * @param $joinAlias string The alias of the table being joined to.
-     * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
-     * @param $searchProvider DBProvider The search provider. This is used for an internal query invocation for subqueries.
-     * @return string A SQL string representing a complete join condition. Join type is specified within the subclass definition.
-     */
-    public function join($joinAlias, $criteria, $searchProvider)
-    {
-        // Construct your JOIN condition here. Generally this involves wrapping the query in a JOIN condition.
-        $subQuery = $this->query($searchProvider);
-        $query = '';
-        $alias = $this->alias();
-        foreach ($criteria as $key => $column) {
-            // if the string isn't empty, the condition is not the first so prepend it with an AND.
-            if (!empty($query)) {
-                $query .= ' AND ';
-            }
-            $query .= "$joinAlias.$key = $alias.$column";
-        }
-
-        $query = " JOIN ($subQuery) $alias ON " . $query;
-
-        return $query;
-    }
-
-    /**
-     * Get the alias of the database table being used by this parameter instance.
-     * @return string The alias of the table for use in the SQL query.
-     */
-    public function alias()
-    {
-        return "p_de_$this->id";
-    }
 }

--- a/models/PatientDiagnosisParameter.php
+++ b/models/PatientDiagnosisParameter.php
@@ -150,39 +150,4 @@ WHERE p1.id NOT IN (
             "p_d_value_$this->id" => '%' . $this->textValue . '%',
         );
     }
-
-    /**
-     * Generate a SQL fragment representing a JOIN condition to a subquery.
-     * @param $joinAlias string The alias of the table being joined to.
-     * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
-     * @param $searchProvider DBProvider The search provider. This is used for an internal query invocation for subqueries.
-     * @return string A SQL string representing a complete join condition. Join type is specified within the subclass definition.
-     */
-    public function join($joinAlias, $criteria, $searchProvider)
-    {
-        // Construct your JOIN condition here. Generally this involves wrapping the query in a JOIN condition.
-        $subQuery = $this->query($searchProvider);
-        $query = '';
-        $alias = $this->alias();
-        foreach ($criteria as $key => $column) {
-            // if the string isn't empty, the condition is not the first so prepend it with an AND.
-            if (!empty($query)) {
-                $query .= ' AND ';
-            }
-            $query .= "$joinAlias.$key = $alias.$column";
-        }
-
-        $query = " JOIN ($subQuery) $alias ON " . $query;
-
-        return $query;
-    }
-
-    /**
-     * Get the alias of the database table being used by this parameter instance.
-     * @return string The alias of the table for use in the SQL query.
-     */
-    public function alias()
-    {
-        return "p_d_$this->id";
-    }
 }

--- a/models/PatientMedicationParameter.php
+++ b/models/PatientMedicationParameter.php
@@ -142,39 +142,4 @@ WHERE d.name $op '$wildcard' || :p_m_value_$this->id || '$wildcard'
             "p_m_value_$this->id" => $this->textValue,
         );
     }
-
-    /**
-     * Generate a SQL fragment representing a JOIN condition to a subquery.
-     * @param $joinAlias string The alias of the table being joined to.
-     * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
-     * @param $searchProvider DBProvider The search provider. This is used for an internal query invocation for subqueries.
-     * @return string A SQL string representing a complete join condition. Join type is specified within the subclass definition.
-     */
-    public function join($joinAlias, $criteria, $searchProvider)
-    {
-        // Construct your JOIN condition here. Generally this involves wrapping the query in a JOIN condition.
-        $subQuery = $this->query($searchProvider);
-        $query = '';
-        $alias = $this->alias();
-        foreach ($criteria as $key => $column) {
-            // if the string isn't empty, the condition is not the first so prepend it with an AND.
-            if (!empty($query)) {
-                $query .= ' AND ';
-            }
-            $query .= "$joinAlias.$key = $alias.$column";
-        }
-
-        $query = " JOIN ($subQuery) $alias ON " . $query;
-
-        return $query;
-    }
-
-    /**
-     * Get the alias of the database table being used by this parameter instance.
-     * @return string The alias of the table for use in the SQL query.
-     */
-    public function alias()
-    {
-        return "p_m_$this->id";
-    }
 }

--- a/models/PatientNameParameter.php
+++ b/models/PatientNameParameter.php
@@ -110,39 +110,4 @@ WHERE LOWER(CONCAT(c.first_name, ' ', c.last_name)) $op LOWER(:p_n_name_$this->i
             "p_n_name_$this->id" => '%' . $this->patient_name . '%',
         );
     }
-
-    /**
-     * Generate a SQL fragment representing a JOIN condition to a subquery.
-     * @param $joinAlias string The alias of the table being joined to.
-     * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
-     * @param $searchProvider DBProvider The search provider. This is used for an internal query invocation for subqueries.
-     * @return string A SQL string representing a complete join condition. Join type is specified within the subclass definition.
-     */
-    public function join($joinAlias, $criteria, $searchProvider)
-    {
-        // Construct your JOIN condition here. Generally this involves wrapping the query in a JOIN condition.
-        $subQuery = $this->query($searchProvider);
-        $query = '';
-        $alias = $this->alias();
-        foreach ($criteria as $key => $column) {
-            // if the string isn't empty, the condition is not the first so prepend it with an AND.
-            if (!empty($query)) {
-                $query .= ' AND ';
-            }
-            $query .= "$joinAlias.$key = $alias.$column";
-        }
-
-        $query = " JOIN ($subQuery) $alias ON " . $query;
-
-        return $query;
-    }
-
-    /**
-     * Get the alias of the database table being used by this parameter instance.
-     * @return string The alias of the table for use in the SQL query.
-     */
-    public function alias()
-    {
-        return "p_n_$this->id";
-    }
 }

--- a/models/PatientNumberParameter.php
+++ b/models/PatientNumberParameter.php
@@ -107,39 +107,4 @@ WHERE p.hos_num $op :p_num_number_$this->id";
             "p_num_number_$this->id" => $this->number,
         );
     }
-
-    /**
-     * Generate a SQL fragment representing a JOIN condition to a subquery.
-     * @param $joinAlias string The alias of the table being joined to.
-     * @param $criteria array An array of join conditions. The ID for each element is the column name from the aliased table.
-     * @param $searchProvider SearchProvider The search provider. This is used for an internal query invocation for subqueries.
-     * @return mixed A SQL string representing a complete join condition. Join type is specified within the subclass definition.
-     */
-    public function join($joinAlias, $criteria, $searchProvider)
-    {
-        // Construct your JOIN condition here. Generally this involves wrapping the query in a JOIN condition.
-        $subQuery = $this->query($searchProvider);
-        $query = '';
-        $alias = $this->alias();
-        foreach ($criteria as $key => $column) {
-            // if the string isn't empty, the condition is not the first so prepend it with an AND.
-            if (!empty($query)) {
-                $query .= ' AND ';
-            }
-            $query .= "$joinAlias.$key = $alias.$column";
-        }
-
-        $query = " JOIN ($subQuery) $alias ON " . $query;
-
-        return $query;
-    }
-
-    /**
-     * Get the alias of the database table being used by this parameter instance.
-     * @return string The alias of the table for use in the SQL query.
-     */
-    public function alias()
-    {
-        return "p_num_$this->id";
-    }
 }

--- a/tests/unit/models/FamilyHistoryParameterTest.php
+++ b/tests/unit/models/FamilyHistoryParameterTest.php
@@ -79,27 +79,4 @@ WHERE (:f_h_side_0 IS NULL OR fh.side_id = :f_h_side_0)
         // Ensure that all bind values are returned.
         $this->assertEquals($expected, $this->object->bindValues());
     }
-
-    /**
-     * @covers FamilyHistoryParameter::alias()
-     */
-    public function testAlias()
-    {
-        // Ensure that the alias correctly utilises the ID.
-        $expected = 'f_h_0';
-        $this->assertEquals($expected, $this->object->alias());
-    }
-
-    /**
-     * @covers FamilyHistoryParameter::join()
-     */
-    public function testJoin()
-    {
-        $this->object->operation = '=';
-        $innerSql = $this->object->query($this->searchProvider);
-
-        // Ensure that the JOIN string is correct.
-        $expected = " JOIN ($innerSql) f_h_0 ON f_h_1.id = f_h_0.id";
-        $this->assertEquals($expected, $this->object->join('f_h_1', array('id' => 'id'), $this->searchProvider));
-    }
 }

--- a/tests/unit/models/PatientAgeParameterTest.php
+++ b/tests/unit/models/PatientAgeParameterTest.php
@@ -108,29 +108,6 @@ class PatientAgeParameterTest extends CDbTestCase
     }
 
     /**
-     * @covers PatientAgeParameter::alias()
-     */
-    public function testAlias()
-    {
-        // Ensure that the alias correctly utilises the ID.
-        $expected = 'p_a_0';
-        $this->assertEquals($expected, $this->parameter->alias());
-    }
-
-    /**
-     * @covers PatientAgeParameter::join()
-     */
-    public function testJoin()
-    {
-        $this->parameter->operation = '=';
-        $innerSql = $this->parameter->query($this->searchProvider);
-
-        // Ensure that the JOIN string is correct.
-        $expected = " JOIN ($innerSql) p_a_0 ON p_a_1.id = p_a_0.id";
-        $this->assertEquals($expected, $this->parameter->join('p_a_1', array('id' => 'id'), $this->searchProvider));
-    }
-
-    /**
      * @covers DBProvider::search()
      * @covers PatientAgeParameter::query()
      */
@@ -161,6 +138,10 @@ class PatientAgeParameterTest extends CDbTestCase
         $this->assertEmpty($results);
     }
 
+    /**
+     * @covers DBProvider::search()
+     * @covers PatientAgeParameter::query()
+     */
     public function testSearchDualInput()
     {
         $patients = array();

--- a/tests/unit/models/PatientAllergyParameterTest.php
+++ b/tests/unit/models/PatientAllergyParameterTest.php
@@ -96,28 +96,9 @@ WHERE p1.id NOT IN (
     }
 
     /**
-     * @covers PatientAllergyParameter::alias()
+     * @covers DBProvider::search()
+     * @covers PatientAllergyParameter::query()
      */
-    public function testAlias()
-    {
-        // Ensure that the alias correctly utilises the ID.
-        $expected = 'p_al_0';
-        $this->assertEquals($expected, $this->object->alias());
-    }
-
-    /**
-     * @covers PatientAllergyParameter::join()
-     */
-    public function testJoin()
-    {
-        $this->object->operation = '=';
-        $innerSql = $this->object->query($this->searchProvider);
-
-        // Ensure that the JOIN string is correct.
-        $expected = " JOIN ($innerSql) p_al_0 ON p_al_1.id = p_al_0.id";
-        $this->assertEquals($expected, $this->object->join('p_al_1', array('id' => 'id'), $this->searchProvider));
-    }
-
     public function testSearch()
     {
         $match = $this->patient('patient7');

--- a/tests/unit/models/PatientDeceasedParameterTest.php
+++ b/tests/unit/models/PatientDeceasedParameterTest.php
@@ -67,28 +67,9 @@ class PatientDeceasedParameterTest extends CDbTestCase
     }
 
     /**
-     * @covers PatientDeceasedParameter::alias()
+     * @covers DBProvider::search()
+     * @covers PatientDeceasedParameter::query()
      */
-    public function testAlias()
-    {
-        // Ensure that the alias correctly utilises the ID.
-        $expected = 'p_de_0';
-        $this->assertEquals($expected, $this->parameter->alias());
-    }
-
-    /**
-     * @covers PatientDeceasedParameter::join()
-     */
-    public function testJoin()
-    {
-        $this->parameter->operation = '0';
-        $innerSql = $this->parameter->query($this->searchProvider);
-
-        // Ensure that the JOIN string is correct.
-        $expected = " JOIN ($innerSql) p_de_0 ON p_a_0.id = p_de_0.id";
-        $this->assertEquals($expected, $this->parameter->join('p_a_0', array('id' => 'id'), $this->searchProvider));
-    }
-
     public function testSearch()
     {
         // Ensure all patient fixtures are returned.

--- a/tests/unit/models/PatientDiagnosisParameterTest.php
+++ b/tests/unit/models/PatientDiagnosisParameterTest.php
@@ -6,8 +6,11 @@
 class PatientDiagnosisParameterTest extends CDbTestCase
 {
     protected $object;
+
+    /**
+     * @var DBProvider
+     */
     protected $searchProvider;
-    protected $invalidProvider;
     protected $fixtures = array(
         'disorder' => 'Disorder',
         'secondary_diagnosis' => 'SecondaryDiagnosis',
@@ -54,20 +57,20 @@ class PatientDiagnosisParameterTest extends CDbTestCase
             foreach ($confirmedStates as $state)
             {
                 $this->object->isConfirmed = $state;
-                $sqlValue = "SELECT p.id 
+                $sqlValue = 'SELECT p.id 
 FROM patient p 
 LEFT JOIN secondary_diagnosis sd 
   ON sd.patient_id = p.id 
 LEFT JOIN disorder d 
   ON d.id = sd.disorder_id 
-WHERE LOWER(d.term) LIKE LOWER(:p_d_value_0)";
+WHERE LOWER(d.term) LIKE LOWER(:p_d_value_0)';
                 if ($state === '0')
                 {
-                    $sqlValue .= " AND sd.is_confirmed = :p_d_confirmed_0";
+                    $sqlValue .= ' AND sd.is_confirmed = :p_d_confirmed_0';
                 }
                 elseif ($state === '1')
                 {
-                    $sqlValue .= " AND (:p_d_confirmed_0 = " . PatientDiagnosisParameter::DIAGNOSIS_CONFIRMED . " AND sd.is_confirmed IS NULL) OR sd.is_confirmed = :p_d_confirmed_0";
+                    $sqlValue .= ' AND ((:p_d_confirmed_0 = ' . PatientDiagnosisParameter::DIAGNOSIS_CONFIRMED . ' AND sd.is_confirmed IS NULL) OR sd.is_confirmed = :p_d_confirmed_0)';
                 }
 
                 if ($operator === 'NOT LIKE')
@@ -115,28 +118,9 @@ WHERE p1.id NOT IN (
     }
 
     /**
-     * @covers PatientDiagnosisParameter::alias()
+     * @covers DBProvider::search()
+     * @covers PatientDiagnosisParameter::query()
      */
-    public function testAlias()
-    {
-        // Ensure that the alias correctly utilises the ID.
-        $expected = 'p_d_0';
-        $this->assertEquals($expected, $this->object->alias());
-    }
-
-    /**
-     * @covers PatientDiagnosisParameter::join()
-     */
-    public function testJoin()
-    {
-        $this->object->operation = 'LIKE';
-        $innerSql = $this->object->query($this->searchProvider);
-
-        // Ensure that the JOIN string is correct.
-        $expected = " JOIN ($innerSql) p_d_0 ON p_d_1.id = p_d_0.id";
-        $this->assertEquals($expected, $this->object->join('p_d_1', array('id' => 'id'), $this->searchProvider));
-    }
-
     public function testSearchLike()
     {
         $expected = array($this->patient('patient1'), $this->patient('patient2'));

--- a/tests/unit/models/PatientMedicationParameterTest.php
+++ b/tests/unit/models/PatientMedicationParameterTest.php
@@ -17,8 +17,7 @@ class PatientMedicationParameterTest extends CTestCase
 
     protected function tearDown()
     {
-        unset($this->object); // start from scratch for each test.
-        unset($this->searchProvider);
+        unset($this->object, $this->searchProvider);
     }
 
     /**
@@ -93,28 +92,5 @@ WHERE d.name $operator '$wildcard' || :p_m_value_0 || '$wildcard'
 
         // Ensure that all bind values are returned.
         $this->assertEquals($expected, $this->object->bindValues());
-    }
-
-    /**
-     * @covers PatientMedicationParameter::alias()
-     */
-    public function testAlias()
-    {
-        // Ensure that the alias correctly utilises the ID.
-        $expected = 'p_m_0';
-        $this->assertEquals($expected, $this->object->alias());
-    }
-
-    /**
-     * @covers PatientMedicationParameter::join()
-     */
-    public function testJoin()
-    {
-        $this->object->operation = 'LIKE';
-        $innerSql = $this->object->query($this->searchProvider);
-
-        // Ensure that the JOIN string is correct.
-        $expected = " JOIN ($innerSql) p_m_0 ON p_m_1.id = p_m_0.id";
-        $this->assertEquals($expected, $this->object->join('p_m_1', array('id' => 'id'), $this->searchProvider));
     }
 }

--- a/tests/unit/models/PatientNameParameterTest.php
+++ b/tests/unit/models/PatientNameParameterTest.php
@@ -23,7 +23,7 @@ class PatientNameParameterTest extends CDbTestCase
     protected function tearDown()
     {
         parent::tearDown();
-        unset($this->parameter, $this->searchProvider, $this->invalidProvider);
+        unset($this->parameter, $this->searchProvider);
     }
 
     /**
@@ -31,8 +31,6 @@ class PatientNameParameterTest extends CDbTestCase
      * @covers DBProvider::executeSearch()
      * @covers PatientNameParameter::query()
      * @covers PatientNameParameter::bindValues()
-     * @covers PatientNameParameter::alias()
-     * @covers PatientNameParameter::join()
      */
     public function testSearch()
     {

--- a/tests/unit/models/PatientNumberParameterTest.php
+++ b/tests/unit/models/PatientNumberParameterTest.php
@@ -6,6 +6,9 @@
 class PatientNumberParameterTest extends CDbTestCase
 {
     protected $parameter;
+    /**
+     * @var DBProvider
+     */
     protected $searchProvider;
     protected $fixtures = array(
         'patient' => 'Patient'
@@ -30,8 +33,6 @@ class PatientNumberParameterTest extends CDbTestCase
      * @covers DBProvider::executeSearch()
      * @covers PatientNumberParameter::query()
      * @covers PatientNumberParameter::bindValues()
-     * @covers PatientNumberParameter::join()
-     * @covers PatientNumberParameter::alias()
      */
     public function testSearch()
     {

--- a/views/caseSearch/index.php
+++ b/views/caseSearch/index.php
@@ -1,5 +1,7 @@
 <?php
 /* @var $this CaseSearchController
+ * @var $fixedParams array
+ * @var $params array
  * @var $trial Trial
  */
 


### PR DESCRIPTION
- Removed join and alias functions as they are no longer required.
- DBProvider query construction now uses IN conditions rather than nested JOINs to allow unordered set operations. This renders the join and alias functions obsolete.
Added some more PSR-2 compliance.
Fixed issue where instanceof was being used on the array of parameters rather than on each parameter itself.
Fixed issue where case search parameters would disappear when navigating between pages.